### PR TITLE
Master

### DIFF
--- a/plugins/e-httpGetFile/src/main/java/com/linkedpipes/plugin/extractor/httpget/HttpGetVocabulary.java
+++ b/plugins/e-httpGetFile/src/main/java/com/linkedpipes/plugin/extractor/httpget/HttpGetVocabulary.java
@@ -4,7 +4,7 @@ package com.linkedpipes.plugin.extractor.httpget;
  *
  * @author Škoda Petr
  */
-final class HttpGetVocabulary {
+public final class HttpGetVocabulary {
 
     private static final String PREFIX
             = "http://plugins.linkedpipes.com/ontology/e-httpGetFile#";


### PR DESCRIPTION
For another project we need HttpGetVocabulary to be public. Just like (most) other vocabulary classes are public.