### PR TITLE
Add redirect to make the previous URL work

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,6 +35,7 @@ gems:
   - jekyll-mentions
   - jekyll-feed
   - jekyll-sitemap
+  - jekyll-redirect-from
 
 exclude:
   - api-commons

--- a/_tutorials/csv-to-rdf/index.html
+++ b/_tutorials/csv-to-rdf/index.html
@@ -1,6 +1,7 @@
 ---
 file: index.html
 short: "CSV to RDF"
+redirect_from: /tutorials/csv-to-rdf/introduction
 title: Converting tabular data to RDF
 ---
 


### PR DESCRIPTION
The previous URL of the CSV to RDF tutorial (`/tutorials/csv-to-rdf/introduction`) has been circulated widely, so this PR simply adds a redirect to make it work again.