### PR TITLE
remove incorrect content-type header in x-httpRequest when doing a POST with body

### DIFF
--- a/plugins/x-httpRequest/src/main/java/com/linkedpipes/plugin/exec/httprequest/TaskExecutor.java
+++ b/plugins/x-httpRequest/src/main/java/com/linkedpipes/plugin/exec/httprequest/TaskExecutor.java
@@ -158,7 +158,6 @@ class TaskExecutor implements TaskConsumer<HttpRequestTask> {
             HttpURLConnection connection, HttpRequestTask.Content content)
             throws IOException {
         connection.setDoOutput(true);
-        connection.addRequestProperty("Content-Type", "application/" + "POST");
         taskContentWriter.writeContentToConnection(connection, content);
         return new Connection(connection);
     }


### PR DESCRIPTION
The x-HttpRequest currently sets a (forced) content-type of "application/POST" when posting content as a body. This PR removes that header so it's possible to set the content-type from the plugins configuration. 

I have not provided the application/POST as a default value for the content-type header because it does not seem to be valid content-type,