### PR TITLE
bump spring framework to 5.3.18

### DIFF
--- a/pom-backend/pom.xml
+++ b/pom-backend/pom.xml
@@ -28,7 +28,7 @@
         <junit.version>5.7.2</junit.version>
         <lp.version>0.0.0</lp.version>
         <commons-io.version>2.8.0</commons-io.version>
-        <springframework.version>5.3.6</springframework.version>
+        <springframework.version>5.3.18</springframework.version>
         <jetty.version>9.4.41.v20210516</jetty.version>
     </properties>
 


### PR DESCRIPTION
Though the spring framework RCE vulnerability is currently unproven to work on jetty, it's probably best to upgrade.
More information is available here https://spring.io/blog/2022/03/31/spring-framework-rce-early-announcement

Note: I did not test this PR, but patch bumps of the framework should not affect the software.